### PR TITLE
Fix: Remove unused scripting permission to comply with Chrome Web Store policy

### DIFF
--- a/manifests/chrome/manifest.json
+++ b/manifests/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 3,
   "action": {
     "default_popup": "popup.html",
@@ -14,7 +14,6 @@
   "permissions": [
     "storage",
     "alarms",
-    "scripting",
     "declarativeNetRequest"
   ],
   "host_permissions": [

--- a/manifests/edge/manifest.json
+++ b/manifests/edge/manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
   "short_description": "Easily manage HTTP headers across your favorite websites",
   "author": "Open Headers",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 3,
   "action": {
     "default_popup": "popup.html",
@@ -16,7 +16,6 @@
   "permissions": [
     "storage",
     "alarms",
-    "scripting",
     "declarativeNetRequest"
   ],
   "host_permissions": [

--- a/manifests/firefox/manifest.json
+++ b/manifests/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {
@@ -20,7 +20,6 @@
   "permissions": [
     "storage",
     "alarms",
-    "scripting",
     "declarativeNetRequest"
   ],
   "host_permissions": [

--- a/manifests/safari/manifest.json
+++ b/manifests/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 3,
   "author": "Your Name",
   "action": {
@@ -15,7 +15,6 @@
   "permissions": [
     "storage",
     "alarms",
-    "scripting",
     "declarativeNetRequest"
   ],
   "host_permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A browser extension to view and manage HTTP headers",
   "scripts": {
     "build": "npm run build:chrome && npm run build:firefox && npm run build:edge && npm run build:safari",

--- a/shared/popup.html
+++ b/shared/popup.html
@@ -140,7 +140,7 @@
             </a>
         </div>
         <div class="footer-text">
-            Open Headers | Version 1.1.1
+            Open Headers | Version 1.1.2
         </div>
     </div>
 </footer>


### PR DESCRIPTION
## Description
This merge request removes the unused "scripting" permission from the extension's manifest.json file to address a Chrome Web Store rejection.

## Changes
- Removed "scripting" permission from manifest.json
- Updated version from 1.1.1 to 1.1.2

## Context
The Chrome Web Store rejected our extension with the following reason:
- **Violation reference ID:** Purple Potassium
- **Violation:** Requesting but not using the following permission(s): scripting
- **How to rectify:** Remove the above permission

## Testing
- Tested the extension in Chrome, Firefox, and Edge to confirm functionality is not affected
- Verified headers are still correctly applied to requests
- Confirmed WebSocket connection to companion app still works properly

## Related Issues
Addresses Chrome Web Store rejection from April 26, 2025