### PR TITLE
feat: add source-zip script for Firefox add-on submissions

### DIFF
--- a/config/scripts/source-code-zip.js
+++ b/config/scripts/source-code-zip.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const archiver = require('archiver');
+
+const rootDir = path.join(__dirname, '..', '..');
+const outputDir = path.join(rootDir, 'releases');
+const version = require(path.join(rootDir, 'package.json')).version;
+const zipFileName = `open-headers-source-v${version}.zip`;
+const outputPath = path.join(outputDir, zipFileName);
+
+// Ensure releases directory exists
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+// Create a file stream for the output zip
+const output = fs.createWriteStream(outputPath);
+const archive = archiver('zip', {
+  zlib: { level: 9 } // Maximum compression
+});
+
+// Patterns to exclude (using glob patterns)
+const excludePatterns = [
+  'node_modules/**',
+  '.idea/**',
+  '.claude/**',
+  'dist/**',
+  'build/**',
+  'releases/**',
+  '.git/**',
+  '.DS_Store',
+  '*.log',
+  '*.zip',
+  '*.crx',
+  '*.pem',
+  '.env*',
+  'CLAUDE.md',
+  'release-*.md',
+  'manifests/safari/xcode_project/**',
+  '.eslintcache',
+  'coverage/**',
+  '.tmp/**',
+  '*.tgz'
+];
+
+// Listen for archive events
+output.on('close', () => {
+  const sizeMB = (archive.pointer() / 1024 / 1024).toFixed(2);
+  console.log(`✅ Source code zip created successfully!`);
+  console.log(`📦 File: ${outputPath}`);
+  console.log(`📏 Size: ${sizeMB} MB`);
+  console.log(`\n🦊 Ready for Firefox submission!`);
+});
+
+archive.on('error', (err) => {
+  console.error('❌ Error creating zip:', err);
+  throw err;
+});
+
+archive.on('warning', (err) => {
+  if (err.code === 'ENOENT') {
+    console.warn('⚠️  Warning:', err);
+  } else {
+    throw err;
+  }
+});
+
+// Pipe archive data to the file
+archive.pipe(output);
+
+console.log('📦 Creating source code zip for Firefox submission...');
+console.log(`📝 Version: ${version}`);
+console.log(`🚫 Excluding: node_modules, dist, build, IDE files, etc.\n`);
+
+// Add the entire directory with exclusions
+archive.glob('**/*', {
+  cwd: rootDir,
+  ignore: excludePatterns,
+  dot: true // Include dot files (except those excluded)
+});
+
+
+// Finalize the archive
+archive.finalize();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A browser extension to view and manage HTTP headers",
   "scripts": {
     "build": "npm run build:chrome && npm run build:firefox && npm run build:edge && npm run build:safari",
@@ -15,7 +15,8 @@
     "dev:safari": "webpack --config config/webpack/webpack.safari.js --watch",
     "safari:convert": "mkdir -p manifests/safari/xcode_project && xcrun safari-web-extension-converter ./dist/safari --app-name \"Open Headers\" --bundle-identifier \"com.openheaders.safari\" --copy-resources --project-location .manifests/safari/xcode_project",
     "postbuild": "node config/scripts/build-utils.js",
-    "release": "node config/scripts/release.js"
+    "release": "node config/scripts/release.js",
+    "source-zip": "node config/scripts/source-code-zip.js"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
- Add npm script to generate source code zip excluding build artifacts
- Create automated packaging for Firefox store requirements
- Exclude unnecessary files: node_modules, dist, IDE files, etc.
- Bump version to 2.1.1

The source-zip command creates a clean source archive that meets Firefox's submission requirements for source code review.