### PR TITLE
feat: add MIT license, website link and update version to 2.1.2

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OpenHeaders
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A modern browser extension for managing HTTP headers with static and dynamic sou
 ### Manual Installation (Developer Mode)
 
 #### Chrome, Edge
-1. Download and unzip the latest release from [GitHub Releases](https://github.com/OpenHeaders/open-headers-browser-extension/releases)
+1. Download and unzip the latest release from [Open Headers website](https://openheaders.io)
 2. Open the browser and navigate to the extensions page
    - Chrome: `chrome://extensions/`
    - Edge: `edge://extensions/`
@@ -86,7 +86,7 @@ The welcome experience adapts to your specific browser, showing only relevant st
 
 For dynamic sources (HTTP requests, files, environment variables), you'll need the Open Headers companion app:
 
-- [Download for macOS, Windows, and Linux](https://github.com/OpenHeaders/open-headers-app/releases)
+- [Download for macOS, Windows, and Linux](https://openheaders.io)
 
 ## 📖 Usage
 
@@ -296,6 +296,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## 🔗 Links
 
+- [Open Headers Website](https://openheaders.io)
 - [GitHub Repository](https://github.com/OpenHeaders/open-headers-browser-extension)
 - [Companion App](https://github.com/OpenHeaders/open-headers-app)
 - [Report Issues](https://github.com/OpenHeaders/open-headers-browser-extension/issues)

--- a/manifests/chrome/manifest.json
+++ b/manifests/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "manifest_version": 3,
   "action": {
     "default_popup": "popup.html",

--- a/manifests/edge/manifest.json
+++ b/manifests/edge/manifest.json
@@ -2,7 +2,7 @@
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
   "author": "Open Headers",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "manifest_version": 3,
   "action": {
     "default_popup": "popup.html",

--- a/manifests/firefox/manifest.json
+++ b/manifests/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {

--- a/manifests/safari/manifest.json
+++ b/manifests/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Open Headers",
   "description": "Manage HTTP headers with static and dynamic sources and content auto-refresh. Dynamic sources: requests, env vars, files.",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "manifest_version": 3,
   "author": "Open Headers",
   "action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-headers",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-headers",
-      "version": "2.0.0",
+      "version": "2.1.2",
       "dependencies": {
         "@ant-design/icons": "^5.2.6",
         "antd": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A browser extension to view and manage HTTP headers",
   "scripts": {
     "build": "npm run build:chrome && npm run build:firefox && npm run build:edge && npm run build:safari",

--- a/src/assets/export/export.html
+++ b/src/assets/export/export.html
@@ -284,7 +284,7 @@
 </div>
 
 <div class="footer">
-    <p>Open Headers v2.1.0 • <a href="https://github.com/OpenHeaders/open-headers-browser-extension" target="_blank">GitHub</a></p>
+    <p>Open Headers v2.1.2 • <a href="https://openheaders.io" target="_blank">Website</a></p>
 </div>
 
 <script src="js/export.js"></script>

--- a/src/assets/import/import.html
+++ b/src/assets/import/import.html
@@ -359,7 +359,7 @@
 </div>
 
 <div class="footer">
-    <p>Open Headers v2.1.0 • <a href="https://github.com/OpenHeaders/open-headers-browser-extension" target="_blank">GitHub</a></p>
+    <p>Open Headers v2.1.2 • <a href="https://openheaders.io" target="_blank">Website</a></p>
 </div>
 
 <script src="js/import.js"></script>

--- a/src/assets/welcome/welcome.html
+++ b/src/assets/welcome/welcome.html
@@ -789,7 +789,7 @@
                         <p class="step-description">
                             Make sure you have the Open Headers local app installed and running on your computer.
                         </p>
-                        <a href="https://github.com/OpenHeaders/open-headers-app/releases" target="_blank" class="button" id="download-app-button">Download App</a>
+                        <a href="https://openheaders.io" target="_blank" class="button" id="download-app-button">Download App</a>
                         <div class="app-status" id="app-status">
                             <div class="loading-spinner"></div>
                             <span id="app-status-text">Waiting for app to start...</span>
@@ -926,7 +926,7 @@
 </div>
 
 <div class="footer">
-    <p>Open Headers v2.1.0 • <a href="https://github.com/OpenHeaders/open-headers-browser-extension" target="_blank">GitHub</a></p>
+    <p>Open Headers v2.1.2 • <a href="https://openheaders.io" target="_blank">Website</a></p>
 </div>
 
 <script src="js/welcome.js"></script>

--- a/src/popup/components/ConnectionInfo.jsx
+++ b/src/popup/components/ConnectionInfo.jsx
@@ -78,7 +78,7 @@ const ConnectionInfo = () => {
                     type="primary"
                     size="small"
                     icon={<DownloadOutlined />}
-                    onClick={() => window.open('https://github.com/OpenHeaders/open-headers-app/releases', '_blank')}
+                    onClick={() => window.open('https://openheaders.io', '_blank')}
                 >
                   Download
                 </Button>

--- a/src/popup/components/Footer.jsx
+++ b/src/popup/components/Footer.jsx
@@ -4,7 +4,7 @@ import {
   ExportOutlined,
   ImportOutlined,
   QuestionCircleOutlined,
-  GithubOutlined
+  GlobalOutlined
 } from '@ant-design/icons';
 import { storage, runtime, isFirefox } from '../../utils/browser-api';
 
@@ -33,7 +33,7 @@ const Footer = () => {
   const fileInputRef = useRef(null);
 
   // Version information
-  const version = '2.1.0';
+  const version = '2.1.2';
 
   // Handle export configuration
   const handleExport = async () => {
@@ -205,11 +205,11 @@ const Footer = () => {
     }
   };
 
-  // Handle opening GitHub page
-  const handleOpenGitHub = async () => {
+  // Handle opening website
+  const handleOpenWebsite = async () => {
     const response = await sendMessageSafely({
       type: 'openTab',
-      url: 'https://github.com/OpenHeaders/open-headers-browser-extension'
+      url: 'https://openheaders.io'
     });
     if (!response.error) {
       window.close();
@@ -265,8 +265,8 @@ const Footer = () => {
             <Text style={{ fontSize: '11px', color: '#8c8c8c' }}>v{version}</Text>
             <Button
                 type="text"
-                icon={<GithubOutlined />}
-                onClick={handleOpenGitHub}
+                icon={<GlobalOutlined />}
+                onClick={handleOpenWebsite}
                 size="small"
                 style={{ padding: '0 4px', height: '20px', minWidth: 'auto' }}
             />


### PR DESCRIPTION
- Add MIT LICENSE.md file
- Replace GitHub icon with website icon in popup footer
- Update download links to point to openheaders.io
- Add Open Headers website link to README while keeping GitHub links